### PR TITLE
Fix: setting initialPage directly calls details page on small screen

### DIFF
--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -108,14 +108,15 @@ class _MasterDetailsFlowState extends State<MasterDetailsFlow> {
   @override
   void initState() {
     super.initState();
-    if (widget.initialPage != null &&
-        window.physicalSize.width >= widget.breakpoint) {
+    if (widget.initialPage != null) {
       assert(
         widget.initialPage! < widget.items.length,
         'Initial page out of bounds',
       );
       selectedItem = widget.items[widget.initialPage!] as MasterItem;
-      focus = Focus.details;
+      if (window.physicalSize.width >= widget.breakpoint) {
+        focus = Focus.details;
+      }
     }
   }
 

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:animations/animations.dart';
 import 'package:flutter/material.dart' hide Focus;
 import 'package:master_detail_flow/src/enums.dart';
@@ -106,7 +108,8 @@ class _MasterDetailsFlowState extends State<MasterDetailsFlow> {
   @override
   void initState() {
     super.initState();
-    if (widget.initialPage != null) {
+    if (widget.initialPage != null &&
+        window.physicalSize.width >= widget.breakpoint) {
       assert(
         widget.initialPage! < widget.items.length,
         'Initial page out of bounds',


### PR DESCRIPTION
When initialPage has a value, it directly navigates to the appropriate details page on small screens (less than the breakpoint) without showing the master listview. If null, it works as expected. 
This PR ensures that master list-view is shown on smaller screens.