### PR TITLE
Export Focus enum

### DIFF
--- a/lib/master_detail_flow.dart
+++ b/lib/master_detail_flow.dart
@@ -1,7 +1,8 @@
 library master_detail_flow;
 
 export 'package:master_detail_flow/src/details_item.dart' show DetailsItem;
-export 'package:master_detail_flow/src/enums.dart' show DetailsAppBarSize;
+export 'package:master_detail_flow/src/enums.dart'
+    show DetailsAppBarSize, Focus;
 export 'package:master_detail_flow/src/flow_settings.dart'
     show MasterDetailsFlowSettings;
 export 'package:master_detail_flow/src/master_item.dart'


### PR DESCRIPTION
_initialFocus_ variable was introduced in #7. But the _Focus_ enum was not exported from the library preventing user from passing appropriate value.